### PR TITLE
Fix folder name crash

### DIFF
--- a/src/mods/Deck Creator/ADeckCreatorModule.lua
+++ b/src/mods/Deck Creator/ADeckCreatorModule.lua
@@ -15,7 +15,7 @@ local function customLoader(moduleName)
         return moduleCache[filename]
     end
 
-    local filePath = "Mods/Deck Creator/" .. filename
+    local filePath = SMODS.current_mod.path .. filename
     local fileContent = love.filesystem.read(filePath)
     if fileContent then
         local moduleFunc = assert(load(fileContent, "@"..filePath))


### PR DESCRIPTION
Use `SMODS.current_mod.path` instead of a hardcoded string, to prevent crashing on start as in #29 and #31.

(atuhor's nose, i don't go to this mod so i was unable to actually test the fix, but i see no reason why it should be a problem)